### PR TITLE
Add "meter to deltaLngLat" conversions. Remove COORDINATE_SYSTEM constants.

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,15 +219,62 @@ Unprojects a screen point `[x, y]` on the map or world `[lng, lat]` on sphere.
 * `returns` - [x,y] - An Array of Numbers representing map or world coordinates.
 
 Parameters:
-
  - `pixels` {Array} - `[x, y]`
+
 
 #### `WebMercatorViewport.unprojectFlat([x, y], scale = this.scale)`
 
-Returns:
+
+Parameters:
  - `[lng, lat]` array xy - object with {x,y} members representing a "point on projected map
 plane
-* `returns` [lat, lon] or [x, y] of point on sphere.
+Returns:
+* [lat, lon] or [x, y] of point on sphere.
+
+
+#### `getDistanceScales()`
+
+Returns:
+- An object with precalculated distance scales allowing conversion between
+  lnglat deltas, meters and pixels.
+
+Remarks:
+* The returned scales represent simple linear approximations of the local
+  Web Mercator projection scale around the viewport center. Error increases
+  with distance from viewport center (Very roughly 1% per 100km).
+* When converting numbers to 32 bit floats (e.g. for use in WebGL shaders)
+  distance offsets can sometimes be used to gain additional computational
+  precision, which can greatly outweigh the small linear approximation error
+  mentioned above.
+
+
+#### `metersToLngLatDelta(xyz)`
+
+Converts a meter offset to a lnglat offset using linear approximation.
+For information on numerical precision, see remarks on `getDistanceScales`.
+
+* `xyz` ([Number,Number]|[Number,Number,Number])  - array of meter deltas
+returns ([Number,Number]|[Number,Number,Number]) - array of [lng,lat,z] deltas
+
+
+#### `lngLatDeltaToMeters(deltaLngLatZ)`
+
+Converts a lnglat offset to a meter offset using linear approximation.
+For information on numerical precision, see remarks on `getDistanceScales`.
+
+* `deltaLngLatZ` ([Number,Number]|[Number,Number,Number])  - array of [lng,lat,z] deltas
+Returns ([Number,Number]|[Number,Number,Number]) - array of meter deltas
+
+
+#### `addMetersToLngLat(lngLatZ, xyz)`
+
+Add a meter delta to a base lnglat coordinate, returning a new lnglat array,
+using linear approximation.
+For information on numerical precision, see remarks on `getDistanceScales`.
+
+* `lngLatZ` ([Number,Number]|[Number,Number,Number]) - base coordinate
+* `xyz` ([Number,Number]|[Number,Number,Number])  - array of meter deltas
+Returns ([Number,Number]|[Number,Number,Number]) array of [lng,lat,z] deltas
 
 
 ## Viewport

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viewport-mercator-project",
-  "version": "3.0.0-rc1",
+  "version": "3.0.0-rc2",
   "description": "Convert to and from lat/lng and pixels in web mercator at arbitrary floating point zoom levels.",
   "main": "index.js",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -8,5 +8,3 @@ export {default as Viewport} from './viewport';
 export {default as PerspectiveViewport} from './perspective-viewport';
 export {default as OrthographicViewport} from './orthographic-viewport';
 export {default as WebMercatorViewport} from './web-mercator-viewport';
-
-export {COORDINATE_SYSTEM} from './web-mercator-viewport';


### PR DESCRIPTION
* Adds new `WebMercatorViewport` functions for converting between meter and lnglat offsets
* Adds lnglat scales (in addition to meter scales) to `getDistanceScales`.
* Adds documentation and test cases for the new functions.
* Removes the `COORDINATE_SYSTEM` constants (they were not used in this module and belong in `deck.gl`)

@gnavvy @shaojingli @Pessimistress @apercu for visibility.