### PR TITLE
Fixing FlatMercatorViewport parameter table

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Note: The `FlatMercatorViewport` is completely independent of the other classes
 in this module and is intended as a fast, simple solution for applications
 that only use 2D map projections.
 
+| Parameter     |   Type   | Default | Description                                                |
+| ------------- | -------- | ------- | ---------------------------------------------------------- |
 | `latitude`    | `Number` | 37      | Center of viewport on map (alternative to center)          |
 | `longitude`   | `Number` | -122    | Center of viewport on map (alternative to center)          |
 | `zoom`        | `Number` | 11      | Scale = Math.pow(2,zoom) on map (alternative to opt.scale) |
@@ -132,10 +134,6 @@ Remarks:
   web mercator parameters) the `PerspectiveMercatorViewport` is necessary.
 
 ### Constructor
-
-| Parameter    |   Type  | Default | Description                                        |
-| ------------ | ------- | ------- | -------------------------------------------------- |
-
 
 | Parameter     |  Type    | Default | Description                                                |
 | ------------- | -------- | ------- | ---------------------------------------------------------- |


### PR DESCRIPTION
Looks like a line of markdown got broken off of the FlatMercatorViewport description, so I moved it back to fix the formatting...
### Current
![uber-common_viewport-mercator-project__a_map_viewport_converter_using_mercator_projection](https://cloud.githubusercontent.com/assets/2466842/25928892/9a0ca1cc-35b3-11e7-8ad8-d97b860da587.png)
### With Patch
![cazzer_viewport-mercator-project_at_readme-table-patch](https://cloud.githubusercontent.com/assets/2466842/25928904/b003beac-35b3-11e7-9f34-786d2082942d.png)
