### PR TITLE
Add `fitBounds` method to PerspectiveMercatorViewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 4.0 Minor Releases
 
+[TBD]
+- NEW: `PerspectiveMercatorViewport.fitBounds` method
+
 ### 4.0.2
 - FIX Make mapbox a devDependency instead of a dependency (only used for testing)
 

--- a/README.md
+++ b/README.md
@@ -273,3 +273,14 @@ For information on numerical precision, see remarks on `getDistanceScales`.
 * `lngLatZ` ([Number,Number]|[Number,Number,Number]) - base coordinate
 * `xyz` ([Number,Number]|[Number,Number,Number])  - array of meter deltas
 Returns ([Number,Number]|[Number,Number,Number]) array of [lng,lat,z] deltas
+
+
+#### `fitBounds(bounds, options)`
+
+Get a new flat viewport that fits around the given bounding box.
+
+* `bounds` ([[Number,Number],[Number,Number]]) - an array of two opposite corners of
+the bounding box. Each corner is specified in `[lon, lat]`.
+* `options` (Object)
+  + `options.padding` (Number, optional) - The amount of padding in pixels to add to the given bounds from the edge of the viewport.
+  + `options.offset` ([Number,Number], optional) - The center of the given bounds relative to the viewport's center, `[x, y]` measured in pixels.

--- a/src/perspective-mercator-viewport.js
+++ b/src/perspective-mercator-viewport.js
@@ -253,9 +253,8 @@ export default class WebMercatorViewport extends Viewport {
   }
 
   /**
-   * Returns map settings {latitude, longitude, zoom}
-   * that will contain the provided corners within the provided
-   * width.
+   * Returns a new viewport that fit around the given rectangle.
+   * Only supports non-perspective mode.
    * @param {Array} bounds - [[lon, lat], [lon, lat]]
    * @param {Number} [options.padding] - The amount of padding in pixels to add to the given bounds.
    * @param {Array} [options.offset] - The center of the given bounds relative to the map's center,
@@ -440,8 +439,8 @@ function makeViewMatrixFromMercatorParams({
 
 /**
  * Returns map settings {latitude, longitude, zoom}
- * that will contain the provided corners within the provided
- * width.
+ * that will contain the provided corners within the provided width.
+ * Only supports non-perspective mode.
  * @param {Number} width - viewport width
  * @param {Number} height - viewport height
  * @param {Array} bounds - [[lon, lat], [lon, lat]]

--- a/src/perspective-mercator-viewport.js
+++ b/src/perspective-mercator-viewport.js
@@ -252,6 +252,22 @@ export default class WebMercatorViewport extends Viewport {
       [lng + deltaLng, lat + deltaLat, Z + deltaZ];
   }
 
+  /**
+   * Returns map settings {latitude, longitude, zoom}
+   * that will contain the provided corners within the provided
+   * width.
+   * @param {Array} bounds - [[lon, lat], [lon, lat]]
+   * @param {Number} [options.padding] - The amount of padding in pixels to add to the given bounds.
+   * @param {Array} [options.offset] - The center of the given bounds relative to the map's center,
+   *    [x, y] measured in pixels.
+   * @returns {WebMercatorViewport}
+   */
+  fitBounds(bounds, options = {}) {
+    const {width, height} = this;
+    const {longitude, latitude, zoom} = fitBounds(Object.assign({width, height, bounds}, options));
+    return new WebMercatorViewport({width, height, longitude, latitude, zoom});
+  }
+
   // INTERNAL METHODS
 
   _getParams() {
@@ -420,4 +436,58 @@ function makeViewMatrixFromMercatorParams({
   mat4.translate(vm, vm, [-center[0], -center[1], 0]);
   // console.log(`VIEWPT T ${pitch * DEGREES_TO_RADIANS} ${-bearing * DEGREES_TO_RADIANS} ${vm}`);
   return vm;
+}
+
+/**
+ * Returns map settings {latitude, longitude, zoom}
+ * that will contain the provided corners within the provided
+ * width.
+ * @param {Number} width - viewport width
+ * @param {Number} height - viewport height
+ * @param {Array} bounds - [[lon, lat], [lon, lat]]
+ * @param {Number} [padding] - The amount of padding in pixels to add to the given bounds.
+ * @param {Array} [offset] - The center of the given bounds relative to the map's center,
+ *    [x, y] measured in pixels.
+ * @returns {Object} - latitude, longitude and zoom
+ */
+export function fitBounds({
+  width,
+  height,
+  bounds,
+  // options
+  padding = 0,
+  offset = [0, 0]
+}) {
+  const [[west, south], [east, north]] = bounds;
+
+  const viewport = new WebMercatorViewport({
+    width,
+    height,
+    longitude: 0,
+    latitude: 0,
+    zoom: 0
+  });
+
+  const nw = viewport.project([west, north]);
+  const se = viewport.project([east, south]);
+  const size = [
+    Math.abs(se[0] - nw[0]),
+    Math.abs(se[1] - nw[1])
+  ];
+  const center = [
+    (se[0] + nw[0]) / 2,
+    (se[1] + nw[1]) / 2
+  ];
+
+  const scaleX = (width - padding * 2 - Math.abs(offset[0]) * 2) / size[0];
+  const scaleY = (height - padding * 2 - Math.abs(offset[1]) * 2) / size[1];
+
+  const centerLngLat = viewport.unproject(center);
+  const zoom = viewport.zoom + Math.log2(Math.abs(Math.min(scaleX, scaleY)));
+
+  return {
+    longitude: centerLngLat[0],
+    latitude: centerLngLat[1],
+    zoom
+  };
 }

--- a/test/index.js
+++ b/test/index.js
@@ -8,3 +8,5 @@ require('./spec/viewport.spec');
 require('./spec/perspective-mercator-viewport.spec');
 // Specific mercator test cases
 require('./spec/mercator-project-unproject.spec');
+// Fit bounds
+require('./spec/fit-bounds.spec');

--- a/test/spec/fit-bounds.spec.js
+++ b/test/spec/fit-bounds.spec.js
@@ -1,0 +1,68 @@
+import test from 'tape-catch';
+import {fitBounds} from 'viewport-mercator-project/perspective-mercator-viewport';
+import {PerspectiveMercatorViewport} from 'viewport-mercator-project';
+import {toLowPrecision} from '../utils/test-utils';
+
+const FITBOUNDS_TEST_CASES = [
+  [
+    {
+      width: 100,
+      height: 100,
+      bounds: [[-73.9876, 40.7661], [-72.9876, 41.7661]]
+    },
+    {
+      longitude: -73.48759999999997,
+      latitude: 41.26801443944763,
+      zoom: 5.723804361273887
+    }
+  ],
+  [
+    {
+      width: 600,
+      height: 400,
+      bounds: [[-23.407, 64.863], [-23.406, 64.874]],
+      padding: 20,
+      offset: [0, -40]
+    },
+    {
+      longitude: -23.406499999999973,
+      latitude: 64.86850056273362,
+      zoom: 12.89199533073045
+    }
+  ]
+];
+
+test('fitBounds', (t) => {
+  for (const [input, expected] of FITBOUNDS_TEST_CASES) {
+    const result = fitBounds(input);
+
+    t.ok(Number.isFinite(result.longitude), 'get valid longitude');
+    t.ok(Number.isFinite(result.latitude), 'get valid latitude');
+    t.ok(Number.isFinite(result.zoom), 'get valid zoom');
+    t.deepEqual(
+      toLowPrecision(result),
+      toLowPrecision(expected),
+      'valid viewport returned'
+    );
+  }
+  t.end();
+});
+
+test('PerspectiveMercatorViewport.fitBounds', (t) => {
+  for (const [input, expected] of FITBOUNDS_TEST_CASES) {
+    const viewport = new PerspectiveMercatorViewport({
+      longitude: -122,
+      latitude: 37.7,
+      width: input.width,
+      height: input.height,
+      zoom: 11
+    });
+    const result = viewport.fitBounds(input.bounds, input);
+
+    t.ok(result instanceof PerspectiveMercatorViewport, 'get viewport');
+    t.equals(toLowPrecision(result.longitude), toLowPrecision(expected.longitude), 'get correct longitude');
+    t.equals(toLowPrecision(result.latitude), toLowPrecision(expected.latitude), 'get correct latitude');
+    t.equals(toLowPrecision(result.zoom), toLowPrecision(expected.zoom), 'get correct zoom');
+  }
+  t.end();
+});


### PR DESCRIPTION
- Move from `fitBounds` util in react-map-gl
- `viewport.fitBounds(bounds, options)` returns a new viewport