### PR TITLE
Api audit

### DIFF
--- a/docs/api-reference/web-mercator-viewport.md
+++ b/docs/api-reference/web-mercator-viewport.md
@@ -94,51 +94,6 @@ Returns:
  - `[longitude, latitude]`
 
 
-#### `getDistanceScales()`
-
-Returns:
-- An object with precalculated distance scales allowing conversion between
-  lnglat deltas, meters and pixels.
-
-Remarks:
-* The returned scales represent simple linear approximations of the local
-  Web Mercator projection scale around the viewport center. Error increases
-  with distance from viewport center (Very roughly 1% per 100km).
-* When converting numbers to 32 bit floats (e.g. for use in WebGL shaders)
-  distance offsets can sometimes be used to gain additional computational
-  precision, which can greatly outweigh the small linear approximation error
-  mentioned above.
-
-
-#### `metersToLngLatDelta(xyz)`
-
-Converts a meter offset to a lnglat offset using linear approximation.
-For information on numerical precision, see remarks on `getDistanceScales`.
-
-* `xyz` ([Number,Number]|[Number,Number,Number])  - array of meter deltas
-returns ([Number,Number]|[Number,Number,Number]) - array of [lng,lat,z] deltas
-
-
-#### `lngLatDeltaToMeters(deltaLngLatZ)`
-
-Converts a lnglat offset to a meter offset using linear approximation.
-For information on numerical precision, see remarks on `getDistanceScales`.
-
-* `deltaLngLatZ` ([Number,Number]|[Number,Number,Number])  - array of [lng,lat,z] deltas
-Returns ([Number,Number]|[Number,Number,Number]) - array of meter deltas
-
-
-#### `addMetersToLngLat(lngLatZ, xyz)`
-
-Add a meter delta to a base lnglat coordinate, returning a new lnglat array,
-using linear approximation.
-For information on numerical precision, see remarks on `getDistanceScales`.
-
-* `lngLatZ` ([Number,Number]|[Number,Number,Number]) - base coordinate
-* `xyz` ([Number,Number]|[Number,Number,Number])  - array of meter deltas
-Returns ([Number,Number]|[Number,Number,Number]) array of [lng,lat,z] deltas
-
-
 #### `fitBounds(bounds, options)`
 
 Get a new flat viewport that fits around the given bounding box.

--- a/src/index.js
+++ b/src/index.js
@@ -9,12 +9,12 @@ export {fitBounds} from './web-mercator-viewport';
 export {
   projectFlat,
   unprojectFlat,
-  getMercatorMeterZoom,
-  getMercatorDistanceScales,
-  getMercatorWorldPosition,
-  makeViewMatricesFromMercatorParams,
-  makeUncenteredViewMatrixFromMercatorParams,
-  makeProjectionMatrixFromMercatorParams,
+  getMeterZoom,
+  getDistanceScales,
+  getWorldPosition,
+  getViewMatrix,
+  getUncenteredViewMatrix,
+  getProjectionMatrix,
   getFov,
   getClippingPlanes
 } from './web-mercator-utils';

--- a/test/spec/web-mercator-utils.spec.js
+++ b/test/spec/web-mercator-utils.spec.js
@@ -6,14 +6,12 @@ import {toLowPrecision} from '../utils/test-utils';
 import {
   projectFlat,
   unprojectFlat,
-  getMercatorMeterZoom,
-  getMercatorDistanceScales,
-  getMercatorWorldPosition,
-  makeUncenteredViewMatrixFromMercatorParams,
-  makeViewMatricesFromMercatorParams,
-  makeProjectionMatrixFromMercatorParams,
-  getFov,
-  getClippingPlanes
+  getMeterZoom,
+  getDistanceScales,
+  getWorldPosition,
+  getUncenteredViewMatrix,
+  getViewMatrix,
+  getProjectionMatrix
 } from 'viewport-mercator-project';
 
 import VIEWPORT_PROPS from '../utils/sample-viewports';
@@ -23,24 +21,22 @@ const DISTANCE_TOLERANCE = 0.001;
 test('Viewport#imports', t => {
   t.ok(projectFlat, 'projectFlat imports OK');
   t.ok(unprojectFlat, 'unprojectFlat imports OK');
-  t.ok(getMercatorMeterZoom, 'getMercatorMeterZoom imports OK');
-  t.ok(getMercatorWorldPosition, 'getMercatorWorldPosition imports OK');
-  t.ok(makeViewMatricesFromMercatorParams, 'makeViewMatricesFromMercatorParams imports OK');
-  t.ok(makeUncenteredViewMatrixFromMercatorParams,
-    'makeUncenteredViewMatrixFromMercatorParams imports OK');
-  t.ok(makeProjectionMatrixFromMercatorParams, 'makeProjectionMatrixFromMercatorParams imports OK');
-  t.ok(getFov, 'getFov imports OK');
-  t.ok(getClippingPlanes, 'getClippingPlanes imports OK');
+  t.ok(getMeterZoom, 'getMeterZoom imports OK');
+  t.ok(getWorldPosition, 'getWorldPosition imports OK');
+  t.ok(getViewMatrix, 'getViewMatrix imports OK');
+  t.ok(getUncenteredViewMatrix,
+    'getUncenteredViewMatrix imports OK');
+  t.ok(getProjectionMatrix, 'getProjectionMatrix imports OK');
   t.end();
 });
 
-test('getMercatorDistanceScales', t => {
+test('getDistanceScales', t => {
   for (const vc in VIEWPORT_PROPS) {
     const props = VIEWPORT_PROPS[vc];
     const {longitude, latitude} = props;
     const {
       metersPerPixel, pixelsPerMeter, degreesPerPixel, pixelsPerDegree
-    } = getMercatorDistanceScales(props);
+    } = getDistanceScales(props);
 
     t.deepEqual([
       toLowPrecision(metersPerPixel[0] * pixelsPerMeter[0]),


### PR DESCRIPTION
- Breaking: util functions are renamed https://github.com/uber-common/viewport-mercator-project/issues/41
- Remove deck.gl `METER_OFFSET` mode related methods from `WebMercatorViewport` (not used - deck.gl implements its own `WebMercatorViewport`) https://github.com/uber-common/viewport-mercator-project/issues/36