### PR TITLE
Add adjustment factor to distance scales

### DIFF
--- a/docs/api-reference/web-mercator-utils.md
+++ b/docs/api-reference/web-mercator-utils.md
@@ -45,15 +45,16 @@ Parameters:
 - `viewport.latitude` (Number, required)
 - `viewport.zoom` (Number, optional)
 - `viewport.scale` (Number, optional) - must supply if zoom is not specified
+- `viewport.highPrecision` (bool, optional) - default `false`
 
 Returns:
 - `distanceScales` (Object)
-- `distanceScales.pixelsPerMeter` (Array) - pixels per meter in `[x, y, z, x2]`
-    + `x2` adjusts `x` by y offset (in meters): `xAdjusted = x + x2 * dy)`. It offers a cheap way to compensate for the `x` changes with latitude.
+- `distanceScales.pixelsPerMeter` (Array) - pixels per meter in `[x, y, z]`.
 - `distanceScales.metersPerPixel` (Array) - meters per pixel in `[x, y, z]`
 - `distanceScales.pixelsPerDegree` (Array) - pixels per degree in `[x, y, z, y2]`
-    + `y2` adjusts `y` by y offset (in degrees): `yAdjusted = y + y2 * dy)`. It offers a cheap way to compensate for the `y` changes with latitude.
 - `distanceScales.degreesPerPixel` (Array) - degree per pixel in `[x, y, z]`
+- `distanceScales.pixelsPerMeter2` (Array) - if `highPrecision` is `true`, returns pixels per meter adjustment in `[x2, y2, z2]`. It offers a cheap way to compensate for the precision loss with latitude. Amends `pixelsPerMeter` by y offset (in meters): `[x + x2 * dy, y + y2 * dy, z + z2 * dy]`.
+- `distanceScales.pixelsPerDegree2` (Array) - if `highPrecision` is `true`, returns pixels per degree adjustment in `[x2, y2, z2]`. It offers a cheap way to compensate for the precision loss with latitude. Amends `pixelsPerDegree` by y offset (in degrees): `[x + x2 * dy, y + y2 * dy, z + z2 * dy]`.
 
 
 ### `getWorldPosition(point)`

--- a/docs/api-reference/web-mercator-utils.md
+++ b/docs/api-reference/web-mercator-utils.md
@@ -48,11 +48,11 @@ Parameters:
 
 Returns:
 - `distanceScales` (Object)
-- `distanceScales.pixelsPerMeter` (Array) - pixels per meter in `[x, y, z, dx]`
-    + `dx` adjusts `x` by y offset (in meters): `xAdjusted = x * (1 + dx * yOffsetMeters)`. It offers a cheap way to compensate for the `x` changes with latitude. 
+- `distanceScales.pixelsPerMeter` (Array) - pixels per meter in `[x, y, z, x2]`
+    + `x2` adjusts `x` by y offset (in meters): `xAdjusted = x + x2 * dy)`. It offers a cheap way to compensate for the `x` changes with latitude.
 - `distanceScales.metersPerPixel` (Array) - meters per pixel in `[x, y, z]`
-- `distanceScales.pixelsPerDegree` (Array) - pixels per degree in `[x, y, z, dy]`
-    + `dy` adjusts `y` by y offset (in degrees): `yAdjusted = y + dy * yOffsetDegrees)`. It offers a cheap way to compensate for the `y` changes with latitude. 
+- `distanceScales.pixelsPerDegree` (Array) - pixels per degree in `[x, y, z, y2]`
+    + `y2` adjusts `y` by y offset (in degrees): `yAdjusted = y + y2 * dy)`. It offers a cheap way to compensate for the `y` changes with latitude.
 - `distanceScales.degreesPerPixel` (Array) - degree per pixel in `[x, y, z]`
 
 

--- a/docs/api-reference/web-mercator-utils.md
+++ b/docs/api-reference/web-mercator-utils.md
@@ -51,7 +51,7 @@ Returns:
 - `distanceScales` (Object)
 - `distanceScales.pixelsPerMeter` (Array) - pixels per meter in `[x, y, z]`.
 - `distanceScales.metersPerPixel` (Array) - meters per pixel in `[x, y, z]`
-- `distanceScales.pixelsPerDegree` (Array) - pixels per degree in `[x, y, z, y2]`
+- `distanceScales.pixelsPerDegree` (Array) - pixels per degree in `[x, y, z]`
 - `distanceScales.degreesPerPixel` (Array) - degree per pixel in `[x, y, z]`
 - `distanceScales.pixelsPerMeter2` (Array) - if `highPrecision` is `true`, returns pixels per meter adjustment in `[x2, y2, z2]`. It offers a cheap way to compensate for the precision loss with latitude. Amends `pixelsPerMeter` by y offset (in meters): `[x + x2 * dy, y + y2 * dy, z + z2 * dy]`.
 - `distanceScales.pixelsPerDegree2` (Array) - if `highPrecision` is `true`, returns pixels per degree adjustment in `[x2, y2, z2]`. It offers a cheap way to compensate for the precision loss with latitude. Amends `pixelsPerDegree` by y offset (in degrees): `[x + x2 * dy, y + y2 * dy, z + z2 * dy]`.

--- a/docs/api-reference/web-mercator-utils.md
+++ b/docs/api-reference/web-mercator-utils.md
@@ -48,9 +48,11 @@ Parameters:
 
 Returns:
 - `distanceScales` (Object)
-- `distanceScales.pixelsPerMeter` (Array) - pixels per meter in `[x, y, z]`
+- `distanceScales.pixelsPerMeter` (Array) - pixels per meter in `[x, y, z, dx]`
+    + `dx` adjusts `x` by y offset (in meters): `xAdjusted = x * (1 + dx * yOffsetMeters)`. It offers a cheap way to compensate for the `x` changes with latitude. 
 - `distanceScales.metersPerPixel` (Array) - meters per pixel in `[x, y, z]`
-- `distanceScales.pixelsPerDegree` (Array) - pixels per degree in `[x, y, z]`
+- `distanceScales.pixelsPerDegree` (Array) - pixels per degree in `[x, y, z, dy]`
+    + `dy` adjusts `y` by y offset (in degrees): `yAdjusted = y + dy * yOffsetDegrees)`. It offers a cheap way to compensate for the `y` changes with latitude. 
 - `distanceScales.degreesPerPixel` (Array) - degree per pixel in `[x, y, z]`
 
 

--- a/docs/get-started/offset-accuracy.md
+++ b/docs/get-started/offset-accuracy.md
@@ -1,0 +1,89 @@
+# Accuracy of Offset Projection
+
+`getDistanceScales` offers a cheap way to project lng/lat or meter offset to pixels. It is useful when using the GPU to project a cluster of coordinates near an origin point, without suffering the precision loss of WebGL.
+
+This article discusses the usage and accuracy of the distance scales.
+
+# Meter offset to pixels
+
+Regular meter offset to pixels projection:
+```
+uniform vec3 pixelsPerMeter;
+vec3 meters_offset_to_pixels_offset(vec3 meters) {
+    return meters * pixelsPerMeter;
+}
+```
+
+When `getDistanceScales` is called with flag `highPrecision: true`, it generates additional multipliers to compensate for precision loss over latitude change. More precise meter offset to pixels projection:
+```
+uniform vec3 pixelsPerMeter;
+uniform vec3 pixelsPerMeter2;
+vec3 meters_offset_to_pixels_offset_adjusted(vec3 meters) {
+    return meters * (pixelsPerMeter + pixelsPerMeter2 * meters.y);
+}
+```
+
+Accuracy at San Francisco (37N, z = 12):
+
+| R   | X unadjusted | X adjusted |
+| --- | ---- | ---- |
+| 100 meters | off by -0.000 pixels, 0.001% | off by 0.000 pixels, 0.001% |
+| 1000 meters | off by -0.008 pixels, 0.012% | off by 0.000 pixels, 0.001% |
+| 5000 meters | off by -0.200 pixels, 0.060% | off by 0.002 pixels, 0.001% |
+| 10000 meters | off by -0.804 pixels, 0.121% | off by 0.003 pixels, 0.000% |
+| 30000 meters | off by -7.277 pixels, 0.366% | off by -0.021 pixels, 0.001% |
+
+
+Accuracy at high latitude (75N, z = 12):
+
+| R   | X unadjusted | X adjusted |
+| --- | ---- | ---- |
+| 100 meters | off by -0.001 pixels, 0.006% | off by 0.000 pixels, 0.001% |
+| 1000 meters | off by -0.130 pixels, 0.061% | off by 0.001 pixels, 0.001% |
+| 5000 meters | off by -3.290 pixels, 0.309% | off by -0.001 pixels, 0.000% |
+| 10000 meters | off by -13.200 pixels, 0.620% | off by -0.044 pixels, 0.002% |
+| 30000 meters | off by -119.884 pixels, 1.877% | off by -1.473 pixels, 0.023% |
+
+
+# LngLat offset to pixels
+
+Regular lng_lat offset to pixels projection:
+```
+uniform vec3 pixelsPerDegree;
+vec3 lnglat_offset_to_pixels_offset(vec3 lngLatZ) {
+    return lngLatZ * pixelsPerDegree;
+}
+```
+
+When `getDistanceScales` is called with flag `highPrecision: true`, it generates additional multipliers to compensate for precision loss over latitude change. More precise meter offset to pixels projection:
+```
+uniform vec3 pixelsPerDegree;
+uniform vec3 pixelsPerDegree2;
+vec3 lnglat_offset_to_pixels_offset_adjusted(vec3 lngLatZ) {
+    return lngLatZ * (pixelsPerDegree + pixelsPerDegree2 * lngLatZ.y);
+}
+```
+
+
+Accuracy at San Francisco (37N, z = 12):
+
+| R   | Y unadjusted | Y adjusted |
+| --- | ---- | ---- |
+| 0.001 degrees | off by -0.000 pixels, 0.001% | off by -0.000 pixels, 0.000% |
+| 0.01 degrees | off by -0.005 pixels, 0.007% | off by -0.000 pixels, 0.000% |
+| 0.05 degrees | off by -0.125 pixels, 0.034% | off by -0.000 pixels, 0.000% |
+| 0.1 degrees | off by -0.499 pixels, 0.068% | off by -0.001 pixels, 0.000% |
+| 0.3 degrees | off by -4.508 pixels, 0.204% | off by -0.022 pixels, 0.001% |
+
+Accuracy at high latitude (75N, z = 12):
+
+| R   | Y unadjusted | Y adjusted |
+| --- | ---- | ---- |
+| 0.001 degrees | off by -0.001 pixels, 0.003% | off by -0.000 pixels, 0.000% |
+| 0.01 degrees | off by -0.081 pixels, 0.034% | off by -0.000 pixels, 0.000% |
+| 0.05 degrees | off by -2.038 pixels, 0.172% | off by -0.005 pixels, 0.000% |
+| 0.1 degrees | off by -8.172 pixels, 0.345% | off by -0.039 pixels, 0.002% |
+| 0.3 degrees | off by -74.258 pixels, 1.046% | off by -1.055 pixels, 0.015% |
+
+
+

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "math.gl": "^1.0.0-alpha.7"
   },
   "devDependencies": {
-    "@turf/distance": "^5.0.4",
+    "@turf/destination": "^5.0.4",
     "babel-cli": "^6.22.2",
     "babel-core": "^6.22.1",
     "babel-eslint": "^6.0.0",

--- a/src/web-mercator-utils.js
+++ b/src/web-mercator-utils.js
@@ -79,9 +79,9 @@ export function getDistanceScales({latitude, longitude, zoom, scale}) {
 
   /**
    * Number of pixels occupied by one degree longitude around current lat/lon:
-     pixelsPerDegreeX = d(projectFlat([lng, lat])/d(lng)
+     pixelsPerDegreeX = d(projectFlat([lng, lat])[0])/d(lng)
        = scale * TILE_SIZE * DEGREES_TO_RADIANS / (2 * PI)
-     pixelsPerDegreeY = d(projectFlat([lng, lat])/d(lat)
+     pixelsPerDegreeY = d(projectFlat([lng, lat])[1])/d(lat)
        = -scale * TILE_SIZE * DEGREES_TO_RADIANS / cos(lat * DEGREES_TO_RADIANS)  / (2 * PI)
    */
   const pixelsPerDegreeX = worldSize / 360;
@@ -100,7 +100,7 @@ export function getDistanceScales({latitude, longitude, zoom, scale}) {
 
   /**
    * Taylor series 2nd order for 1/latCosine
-     f'(a) / (x - a)
+     f'(a) * (x - a)
        = d(1/cos(lat * DEGREES_TO_RADIANS))/d(lat) * dLat
        = DEGREES_TO_RADIANS * tan(lat * DEGREES_TO_RADIANS) / cos(lat * DEGREES_TO_RADIANS) * dLat
    */


### PR DESCRIPTION
This POC adds a 4th component to `pixelsPerMeter` and `pixelsPerDegrees`. If ignored, it doesn't affect the current behavior of offset projection. It offers a cheap way to compensate for the accuracy loss with latitude. If employed, this hack will make the offset projection modes accurate enough to cover an entire city.


# Meter offset to pixels

Current meter offset to pixels projection:
```
uniform vec3 project_uPixelsPerUnit;
vec3 offset_pixels = offset_meters * project_uPixelsPerUnit;
```

Adjusted meter offset to pixels projection:
```
uniform vec4 project_uPixelsPerUnit;
vec3 pixelsPerUnit = project_uPixelsPerUnit.xyz;
pixelsPerUnit.x += project_uPixelsPerUnit.w * offset_meters.y;
vec3 offset_pixels = offset_meters * pixelsPerUnit;
```

San Francisco (37N, z = 12):

| R   | X unadjusted | X adjusted |
| --- | ---- | ---- |
| 100 meters | off by -0.000 pixels, 0.001% | off by 0.000 pixels, 0.001% |
| 1000 meters | off by -0.008 pixels, 0.012% | off by 0.000 pixels, 0.001% |
| 5000 meters | off by -0.200 pixels, 0.060% | off by 0.002 pixels, 0.001% |
| 10000 meters | off by -0.804 pixels, 0.121% | off by 0.003 pixels, 0.000% |
| 30000 meters | off by -7.277 pixels, 0.366% | off by -0.021 pixels, 0.001% |


High Latitude (75N, z = 12):

| R   | X unadjusted | X adjusted |
| --- | ---- | ---- |
| 100 meters | off by -0.001 pixels, 0.006% | off by 0.000 pixels, 0.001% |
| 1000 meters | off by -0.130 pixels, 0.061% | off by 0.001 pixels, 0.001% |
| 5000 meters | off by -3.290 pixels, 0.309% | off by -0.001 pixels, 0.000% |
| 10000 meters | off by -13.200 pixels, 0.620% | off by -0.044 pixels, 0.002% |
| 30000 meters | off by -119.884 pixels, 1.877% | off by -1.473 pixels, 0.023% |


# LngLat offset to pixels

Current lng_lat offset to pixels projection:
```
uniform vec3 project_uPixelsPerDegree;
vec3 offset_pixels = offset_lngLatZ * project_uPixelsPerDegree;
```

Adjusted lng_lat offset to pixels projection:
```
uniform vec4 project_uPixelsPerDegree;
vec3 pixelsPerDegree= project_uPixelsPerDegree.xyz;
pixelsPerDegree.y += project_uPixelsPerDegree.w * offset_lngLatZ.y;
vec3 offset_pixels = offset_lngLatZ * pixelsPerUnit;
```

San Francisco (37N, z = 12):

| R   | Y unadjusted | Y adjusted |
| --- | ---- | ---- |
| 0.001 degrees | off by -0.000 pixels, 0.001% | off by -0.000 pixels, 0.000% |
| 0.01 degrees | off by -0.005 pixels, 0.007% | off by -0.000 pixels, 0.000% |
| 0.05 degrees | off by -0.125 pixels, 0.034% | off by -0.000 pixels, 0.000% |
| 0.1 degrees | off by -0.499 pixels, 0.068% | off by -0.001 pixels, 0.000% |
| 0.3 degrees | off by -4.508 pixels, 0.204% | off by -0.022 pixels, 0.001% |

High Latitude (75N, z = 12):

| R   | Y unadjusted | Y adjusted |
| --- | ---- | ---- |
| 0.001 degrees | off by -0.001 pixels, 0.003% | off by -0.000 pixels, 0.000% |
| 0.01 degrees | off by -0.081 pixels, 0.034% | off by -0.000 pixels, 0.000% |
| 0.05 degrees | off by -2.038 pixels, 0.172% | off by -0.005 pixels, 0.000% |
| 0.1 degrees | off by -8.172 pixels, 0.345% | off by -0.039 pixels, 0.002% |
| 0.3 degrees | off by -74.258 pixels, 1.046% | off by -1.055 pixels, 0.015% |

