### PR TITLE
Rename `getLocationAtPoint` and projection utils

### DIFF
--- a/docs/api-reference/web-mercator-utils.md
+++ b/docs/api-reference/web-mercator-utils.md
@@ -1,6 +1,6 @@
 # Web Mercator Utility Functions
 
-### `projectFlat(lngLat, scale)`
+### `lngLatToWorld(lngLat, scale)`
 
 Project a coordinate on sphere onto the Web Mercator coordinate system at a given zoom level.
 
@@ -12,7 +12,7 @@ Returns:
 - `[x, y]`
 
 
-### `unprojectFlat(xy, scale)`
+### `worldToLngLat(xy, scale)`
 
 Unproject a coordinate from the Web Mercator coordinate system back to the sphere at a given zoom level.
 
@@ -24,7 +24,7 @@ Returns:
 - `[lng, lat]`
 
 
-### `flatCoordinatesToPixels(xyz, projectionMatrix)`
+### `worldToPixels(xyz, projectionMatrix)`
 
 Project a coordinate from the Web Mercator coordinate system to screen.
 
@@ -36,7 +36,7 @@ Returns:
 - `[x, y, z]` - coordinates on screen, `z` is the pixel depth.
 
 
-### `pixelsToFlatCoordinates(xyz, unprojectionMatrix, targetZ)`
+### `pixelsToWorld(xyz, unprojectionMatrix, targetZ)`
 
 Project a coordinate from screen to the Web Mercator coordinate system.
 
@@ -91,6 +91,7 @@ Parameters:
 - `point.longitude` (Number, required)
 - `point.latitude` (Number, required)
 - `point.zoom` (Number, optional)
+- `point.scale` (Number, optional) - must supply if zoom is not specified
 - `point.meterOffset` (Array, optional) - offset from the lat/lon coordinates `[x, y, z]` in meters.
 - `point.distanceScales` (Object, optional) - pre-calculated distance scales using `getDistanceScales`. Supply this parameter to avoid duplicate calculation.
 

--- a/docs/api-reference/web-mercator-utils.md
+++ b/docs/api-reference/web-mercator-utils.md
@@ -24,6 +24,31 @@ Returns:
 - `[lng, lat]`
 
 
+### `flatCoordinatesToPixels(xyz, projectionMatrix)`
+
+Project a coordinate from the Web Mercator coordinate system to screen.
+
+Parameters:
+- `xyz` (Array, required) - Specifies a point in the Web Mercator tile. `z` is the elevation and optional.
+- `projectionMatrix` (Matrix4, required) - The projection matrix.
+
+Returns:
+- `[x, y, z]` - coordinates on screen, `z` is the pixel depth.
+
+
+### `pixelsToFlatCoordinates(xyz, unprojectionMatrix, targetZ)`
+
+Project a coordinate from screen to the Web Mercator coordinate system.
+
+Parameters:
+- `xyz` (Array, required) - Specifies a point on screen. `z` is the pixel depth and optional.
+- `unprojectionMatrix` (Matrix4, required) - The unprojection matrix.
+- `targetZ` (Number, optional) - If pixel depth is not specified, `targetZ` is used as the elevation plane to unproject onto. Default `0`.
+
+Returns:
+- `[x, y, z]` - coordinates on the Web Mercator tile, `z` is the elevation.
+
+
 ### `getMeterZoom(viewport)`
 
 Returns the zoom level that gives a 1 meter pixel at a certain latitude.
@@ -153,3 +178,20 @@ Parameters:
 
 Returns:
 - `{longitude, latitude, zoom}`
+
+
+### `getMapCenterByLngLatPosition(opts)`
+
+Returns the map center that place a given [lng, lat] coordinate at screen point [x, y].Returns the map center that place a given [lng, lat] coordinate at screen point [x, y].
+
+Parameters:
+- `opts` (Object) - options
+- `opts.lngLat` (Array, required) - [lng,lat] coordinates of a location on the sphere.
+- `opts.pos` (Array, required) - [x,y] coordinates of a pixel on screen.
+- `opts.unprojectionMatrix` (Matrix4, required) - unprojection matrix
+- `opts.scale` (Number, required) - Mercator scale
+- `opts.center` (Array, required) - flat coordinates of the map center in the Web Mercator system
+
+Returns:
+- `[longitude, latitude]` new map center
+

--- a/docs/api-reference/web-mercator-utils.md
+++ b/docs/api-reference/web-mercator-utils.md
@@ -178,19 +178,3 @@ Parameters:
 Returns:
 - `{longitude, latitude, zoom}`
 
-
-### `getMapCenterByLngLatPosition(opts)`
-
-Returns the map center that place a given [lng, lat] coordinate at screen point [x, y].Returns the map center that place a given [lng, lat] coordinate at screen point [x, y].
-
-Parameters:
-- `opts` (Object) - options
-- `opts.lngLat` (Array, required) - [lng,lat] coordinates of a location on the sphere.
-- `opts.pos` (Array, required) - [x,y] coordinates of a pixel on screen.
-- `opts.unprojectionMatrix` (Matrix4, required) - unprojection matrix
-- `opts.scale` (Number, required) - Mercator scale
-- `opts.center` (Array, required) - flat coordinates of the map center in the Web Mercator system
-
-Returns:
-- `[longitude, latitude]` new map center
-

--- a/docs/api-reference/web-mercator-utils.md
+++ b/docs/api-reference/web-mercator-utils.md
@@ -91,7 +91,6 @@ Parameters:
 - `point.longitude` (Number, required)
 - `point.latitude` (Number, required)
 - `point.zoom` (Number, optional)
-- `point.scale` (Number, optional) - must supply if zoom is not specified
 - `point.meterOffset` (Array, optional) - offset from the lat/lon coordinates `[x, y, z]` in meters.
 - `point.distanceScales` (Object, optional) - pre-calculated distance scales using `getDistanceScales`. Supply this parameter to avoid duplicate calculation.
 

--- a/docs/api-reference/web-mercator-viewport.md
+++ b/docs/api-reference/web-mercator-viewport.md
@@ -107,7 +107,7 @@ the bounding box. Each corner is specified in `[lon, lat]`.
 
 #### `getMapCenterByLngLatPosition(opts)`
 
-Returns the map center that place a given [lng, lat] coordinate at screen point [x, y].Returns the map center that place a given [lng, lat] coordinate at screen point [x, y].
+Returns the map center that place a given [lng, lat] coordinate at screen point [x, y].
 
 Parameters:
 - `opts` (Object) - options

--- a/docs/api-reference/web-mercator-viewport.md
+++ b/docs/api-reference/web-mercator-viewport.md
@@ -104,3 +104,16 @@ the bounding box. Each corner is specified in `[lon, lat]`.
   + `options.padding` (Number, optional) - The amount of padding in pixels to add to the given bounds from the edge of the viewport.
   + `options.offset` ([Number,Number], optional) - The center of the given bounds relative to the viewport's center, `[x, y]` measured in pixels.
 
+
+#### `getMapCenterByLngLatPosition(opts)`
+
+Returns the map center that place a given [lng, lat] coordinate at screen point [x, y].Returns the map center that place a given [lng, lat] coordinate at screen point [x, y].
+
+Parameters:
+- `opts` (Object) - options
+- `opts.lngLat` (Array, required) - [lng,lat] coordinates of a location on the sphere.
+- `opts.pos` (Array, required) - [x,y] coordinates of a pixel on screen.
+
+Returns:
+- `[longitude, latitude]` new map center
+

--- a/docs/get-started/coordinates.md
+++ b/docs/get-started/coordinates.md
@@ -1,5 +1,11 @@
 # Coordinates
 
+| Coordinates | Description |
+|---------|-------------|
+| LngLat | `[lng, lat, alt]` on earth |
+| World | `[x, y, z]` on the Web Mercator plane |
+| Pixels | `[x, y, depth]` on screen |
+
 ### LngLat Coordinates
 
 LngLat coordinates are specified in

--- a/docs/get-started/coordinates.md
+++ b/docs/get-started/coordinates.md
@@ -1,21 +1,24 @@
-# Notes on Coordinates
+# Coordinates
 
-* For the `project`/`unproject` functions, the default pixel coordinate system of
-  the viewport is defined with the origin in the top left, where the positive
-  x-axis goes right, and the positive y-axis goes down. That is, the
-  top left corner is `[0, 0]` and the bottom right corner is `[width - 1, height - 1]`.
-  The functions have a flag that can reverse this convention.
+### LngLat Coordinates
 
-* Non-pixel projection matrices are obviously bottom left.
+LngLat coordinates are specified in
+`[longitude, latitude, elevation]` where longitude and latitude are in degrees from Greenwich meridian and the equator respectively, and altitude is in meters above sea level.
 
-* Mercator coordinates are specified in "lng-lat" format [lng, lat, z] format
-  (which naturally corresponds to [x, y, z]).
+### World Coordinates
+
+World coordinates specifies a location on the linear Web Mercator plane. Each unit is a "pixel" on the Web Mercator tile. It is unique for each lngLat location at a specific zoom level. `[x, y, z]` corresponds to `[longitude, latitude, elevation]` in the LngLat system.
+
+### Pixel Coordinates
+
+Pixel coordinates specifies a point on screen in the format of `[x, y, z]` where x and y are in pixels on screen and `z` is pixel depth, normally between `-1` and `1`.
+
+By default, the pixel coordinate system of the viewport is defined with the origin in the top left, where the positive x-axis goes right, and the positive y-axis goes down. That is, the top left corner is `[0, 0]` and the bottom right corner is `[width - 1, height - 1]`. The `project`/`unproject` functions have a flag that can reverse this convention.
+
+### Additional Notes
 
 * Per cartographic tradition, all angles including `latitude`, `longitude`,
   `pitch` and `bearing` are specified in degrees, not radians.
-
-* Longitude and latitude are specified in degrees from Greenwich meridian and
-  the equator respectively, and altitude is specified in meters above sea level.
 
 * It is possible to query the PerspectiveMercatorViewport for a meters per pixel scale.
   Note that that distance scales are latitude dependent under

--- a/src/fly-to-viewport.js
+++ b/src/fly-to-viewport.js
@@ -3,8 +3,8 @@ import {lerp} from './math-utils';
 import {
   scaleToZoom,
   zoomToScale,
-  projectFlat,
-  unprojectFlat
+  lngLatToWorld,
+  worldToLngLat
 } from './web-mercator-utils';
 
 const EPSILON = 0.01;
@@ -31,8 +31,8 @@ export default function flyToViewport(startProps, endProps, t) {
   const endCenter = [endProps.longitude, endProps.latitude];
   const scale = zoomToScale(endZoom - startZoom);
 
-  const startCenterXY = new Vector2(projectFlat(startCenter, startScale));
-  const endCenterXY = new Vector2(projectFlat(endCenter, startScale));
+  const startCenterXY = new Vector2(lngLatToWorld(startCenter, startScale));
+  const endCenterXY = new Vector2(lngLatToWorld(endCenter, startScale));
   const uDelta = endCenterXY.subtract(startCenterXY);
 
   const w0 = Math.max(startProps.width, startProps.height);
@@ -65,7 +65,7 @@ export default function flyToViewport(startProps, endProps, t) {
   const scaleIncrement = 1 / w; // Using w method for scaling.
   const newZoom = startZoom + scaleToZoom(scaleIncrement);
 
-  const newCenter = unprojectFlat(
+  const newCenter = worldToLngLat(
     (startCenterXY.add(uDelta.scale(u))).scale(scaleIncrement),
     zoomToScale(newZoom));
   viewport.longitude = newCenter[0];

--- a/src/index.js
+++ b/src/index.js
@@ -7,20 +7,21 @@ export {default as normalizeViewportProps} from './normalize-viewport-props';
 export {default as flyToViewport} from './fly-to-viewport';
 
 export {
-  projectFlat,
-  unprojectFlat,
+  lngLatToWorld,
+  worldToLngLat,
+  worldToPixels,
+  pixelsToWorld,
   getMeterZoom,
   getDistanceScales,
   getWorldPosition,
   getViewMatrix,
   getProjectionMatrix
-  flatCoordinatesToPixels,
-  pixelsToFlatCoordinates,
-  getMapCenterByLngLatPosition
 } from './web-mercator-utils';
 
 // Deprecated
 export {default as PerspectiveMercatorViewport} from './web-mercator-viewport';
 export {
-  getViewMatrix as getUncenteredViewMatrix
+  getViewMatrix as getUncenteredViewMatrix,
+  lngLatToWorld as projectFlat,
+  worldToLngLat as unprojectFlat
 } from './web-mercator-utils';

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,9 @@ export {
   getWorldPosition,
   getViewMatrix,
   getProjectionMatrix
+  flatCoordinatesToPixels,
+  pixelsToFlatCoordinates,
+  getMapCenterByLngLatPosition
 } from './web-mercator-utils';
 
 // Deprecated

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -3,7 +3,7 @@
 /* eslint-disable camelcase */
 import {equals} from 'math.gl';
 import {createMat4} from './math-utils';
-import {flatCoordinatesToPixels, pixelsToFlatCoordinates} from './web-mercator-utils';
+import {worldToPixels, pixelsToWorld} from './web-mercator-utils';
 
 import mat4_scale from 'gl-mat4/scale';
 import mat4_translate from 'gl-mat4/translate';
@@ -126,7 +126,7 @@ export default class Viewport {
     const [x0, y0, z0] = xyz;
 
     const [X, Y] = this.projectFlat([x0, y0]);
-    const coord = flatCoordinatesToPixels([X, Y, z0], this.pixelProjectionMatrix);
+    const coord = worldToPixels([X, Y, z0], this.pixelProjectionMatrix);
 
     const [x, y] = coord;
     const y2 = topLeft ? y : this.height - y;
@@ -149,7 +149,7 @@ export default class Viewport {
     const [x, y, z] = xyz;
 
     const y2 = topLeft ? y : this.height - y;
-    const coord = pixelsToFlatCoordinates([x, y2, z], this.pixelUnprojectionMatrix, targetZ);
+    const coord = pixelsToWorld([x, y2, z], this.pixelUnprojectionMatrix, targetZ);
     const [X, Y] = this.unprojectFlat(coord);
 
     if (Number.isFinite(z)) {

--- a/src/web-mercator-utils.js
+++ b/src/web-mercator-utils.js
@@ -139,12 +139,10 @@ export function getWorldPosition({
   longitude,
   latitude,
   zoom,
-  scale,
   meterOffset,
   distanceScales = null
 }) {
-  // Calculate scale from zoom if not provided
-  scale = scale !== undefined ? scale : zoomToScale(zoom);
+  const scale = zoomToScale(zoom);
 
   // Make a centered version of the matrix for projection modes without an offset
   const center2d = projectFlat([longitude, latitude], scale);

--- a/src/web-mercator-utils.js
+++ b/src/web-mercator-utils.js
@@ -39,7 +39,7 @@ export function scaleToZoom(scale) {
  *   Specifies a point on the sphere to project onto the map.
  * @return {Array} [x,y] coordinates.
  */
-export function projectFlat([lng, lat], scale) {
+export function lngLatToWorld([lng, lat], scale) {
   scale *= TILE_SIZE;
   const lambda2 = lng * DEGREES_TO_RADIANS;
   const phi2 = lat * DEGREES_TO_RADIANS;
@@ -57,7 +57,7 @@ export function projectFlat([lng, lat], scale) {
  *   Has toArray method if you need a GeoJSON Array.
  *   Per cartographic tradition, lat and lon are specified as degrees.
  */
-export function unprojectFlat([x, y], scale) {
+export function worldToLngLat([x, y], scale) {
   scale *= TILE_SIZE;
   const lambda2 = (x / scale) * (2 * PI) - PI;
   const phi2 = 2 * (Math.atan(Math.exp(PI - (y / scale) * (2 * PI))) - PI_4);
@@ -90,9 +90,9 @@ export function getDistanceScales({latitude, longitude, zoom, scale, highPrecisi
 
   /**
    * Number of pixels occupied by one degree longitude around current lat/lon:
-     pixelsPerDegreeX = d(projectFlat([lng, lat])[0])/d(lng)
+     pixelsPerDegreeX = d(lngLatToWorld([lng, lat])[0])/d(lng)
        = scale * TILE_SIZE * DEGREES_TO_RADIANS / (2 * PI)
-     pixelsPerDegreeY = d(projectFlat([lng, lat])[1])/d(lat)
+     pixelsPerDegreeY = d(lngLatToWorld([lng, lat])[1])/d(lat)
        = -scale * TILE_SIZE * DEGREES_TO_RADIANS / cos(lat * DEGREES_TO_RADIANS)  / (2 * PI)
    */
   const pixelsPerDegreeX = worldSize / 360;
@@ -137,13 +137,15 @@ export function getWorldPosition({
   longitude,
   latitude,
   zoom,
+  scale,
   meterOffset,
   distanceScales = null
 }) {
-  const scale = zoomToScale(zoom);
+  // Calculate scale from zoom if not provided
+  scale = scale !== undefined ? scale : zoomToScale(zoom);
 
   // Make a centered version of the matrix for projection modes without an offset
-  const center2d = projectFlat([longitude, latitude], scale);
+  const center2d = lngLatToWorld([longitude, latitude], scale);
   const center = new Vector3(center2d[0], center2d[1], 0);
 
   if (meterOffset) {
@@ -254,39 +256,39 @@ export function getProjectionMatrix({
  * Project flat coordinates to pixels on screen.
  *
  * @param {Array} xyz - flat coordinate on 512*512 Mercator Zoom 0 tile
- * @param {Matrix4} projectionMatrix - projection matrix
+ * @param {Matrix4} pixelProjectionMatrix - projection matrix
  * @return {Array} [x, y, depth] pixel coordinate on screen.
  */
-export function flatCoordinatesToPixels(xyz, projectionMatrix) {
+export function worldToPixels(xyz, pixelProjectionMatrix) {
   const [x, y, z = 0] = xyz;
   assert(isFinite(x) && isFinite(y) && isFinite(z));
 
-  return transformVector(projectionMatrix, [x, y, z, 1]);
+  return transformVector(pixelProjectionMatrix, [x, y, z, 1]);
 }
 
 /**
  * Unproject pixels on screen to flat coordinates.
  *
  * @param {Array} xyz - pixel coordinate on screen.
- * @param {Matrix4} projectionMatrix - unprojection matrix
+ * @param {Matrix4} pixelUnprojectionMatrix - unprojection matrix
  * @param {Number} targetZ - if pixel coordinate does not have a 3rd component (depth),
  *    targetZ is used as the elevation plane to unproject onto
  * @return {Array} [x, y, Z] flat coordinates on 512*512 Mercator Zoom 0 tile.
  */
-export function pixelsToFlatCoordinates(xyz, unprojectionMatrix, targetZ = 0) {
+export function pixelsToWorld(xyz, pixelUnprojectionMatrix, targetZ = 0) {
   const [x, y, z] = xyz;
   assert(isFinite(x) && isFinite(y));
 
   if (Number.isFinite(z)) {
     // Has depth component
-    const coord = transformVector(unprojectionMatrix, [x, y, z, 1]);
+    const coord = transformVector(pixelUnprojectionMatrix, [x, y, z, 1]);
     return coord;
   }
 
   // since we don't know the correct projected z value for the point,
   // unproject two points to get a line and then find the point on that line with z=0
-  const coord0 = transformVector(unprojectionMatrix, [x, y, 0, 1]);
-  const coord1 = transformVector(unprojectionMatrix, [x, y, 1, 1]);
+  const coord0 = transformVector(pixelUnprojectionMatrix, [x, y, 0, 1]);
+  const coord1 = transformVector(pixelUnprojectionMatrix, [x, y, 1, 1]);
 
   const z0 = coord0[2];
   const z1 = coord1[2];

--- a/src/web-mercator-utils.js
+++ b/src/web-mercator-utils.js
@@ -9,8 +9,6 @@ import mat4_translate from 'gl-mat4/translate';
 import mat4_rotateX from 'gl-mat4/rotateX';
 import mat4_rotateZ from 'gl-mat4/rotateZ';
 import vec2_lerp from 'gl-vec2/lerp';
-import vec2_add from 'gl-vec2/add';
-import vec2_negate from 'gl-vec2/negate';
 import assert from 'assert';
 
 // CONSTANTS
@@ -295,30 +293,4 @@ export function pixelsToFlatCoordinates(xyz, unprojectionMatrix, targetZ = 0) {
 
   const t = z0 === z1 ? 0 : ((targetZ || 0) - z0) / (z1 - z0);
   return vec2_lerp([], coord0, coord1, t);
-}
-
-/**
- * Get the map center that place a given [lng, lat] coordinate at screen point [x, y].
- *
- * @param {Array} lngLat - [lng,lat] coordinates of a location on the sphere.
- * @param {Array} pos - [x,y] coordinates of a point on the screen.
- * @param {Matrix4} unprojectionMatrix - unprojection matrix
- * @param {Number} scale - Mercator scale
- * @param {Array} center - Mercator coordinates of the current map center
- * @return {Array} [lng,lat] new map center.
- */
-export function getMapCenterByLngLatPosition({
-  lngLat,
-  pos,
-  unprojectionMatrix,
-  scale,
-  center
-}) {
-  const fromLocation = pixelsToFlatCoordinates(pos, unprojectionMatrix);
-  const toLocation = projectFlat(lngLat, scale);
-
-  const translate = vec2_add([], toLocation, vec2_negate([], fromLocation));
-  const newCenter = vec2_add([], center, translate);
-
-  return unprojectFlat(newCenter, scale);
 }

--- a/src/web-mercator-viewport.js
+++ b/src/web-mercator-viewport.js
@@ -7,13 +7,10 @@ import {
   projectFlat,
   unprojectFlat,
   getProjectionMatrix,
-  getViewMatrix
+  getViewMatrix,
+  getMapCenterByLngLatPosition
 } from './web-mercator-utils';
 import fitBounds from './fit-bounds';
-
-/* eslint-disable camelcase */
-import vec2_add from 'gl-vec2/add';
-import vec2_negate from 'gl-vec2/negate';
 
 export default class WebMercatorViewport extends Viewport {
   /**
@@ -141,15 +138,19 @@ export default class WebMercatorViewport extends Viewport {
    *   Specifies a point on the screen.
    * @return {Array} [lng,lat] new map center.
    */
+  getMapCenterByLngLatPosition({lngLat, pos}) {
+    return getMapCenterByLngLatPosition({
+      lngLat,
+      pos,
+      scale: this.scale,
+      center: this.center,
+      unprojectionMatrix: this.pixelUnprojectionMatrix
+    });
+  }
+
+  // Legacy method name
   getLocationAtPoint({lngLat, pos}) {
-    const fromLocation = this.projectFlat(this.unproject(pos));
-    const toLocation = this.projectFlat(lngLat);
-
-    const center = this.projectFlat([this.longitude, this.latitude]);
-
-    const translate = vec2_add([], toLocation, vec2_negate([], fromLocation));
-    const newCenter = vec2_add([], center, translate);
-    return this.unprojectFlat(newCenter);
+    return this.getMapCenterByLngLatPosition({lngLat, pos});
   }
 
   /**

--- a/src/web-mercator-viewport.js
+++ b/src/web-mercator-viewport.js
@@ -4,9 +4,9 @@ import Viewport from './viewport';
 import {
   zoomToScale,
   getWorldPosition,
-  pixelsToFlatCoordinates,
-  projectFlat,
-  unprojectFlat,
+  pixelsToWorld,
+  lngLatToWorld,
+  worldToLngLat,
   getProjectionMatrix,
   getViewMatrix
 } from './web-mercator-utils';
@@ -115,7 +115,7 @@ export default class WebMercatorViewport extends Viewport {
    * @return {Array} [x,y] coordinates.
    */
   projectFlat(lngLat, scale = this.scale) {
-    return projectFlat(lngLat, scale);
+    return lngLatToWorld(lngLat, scale);
   }
 
   /**
@@ -128,7 +128,7 @@ export default class WebMercatorViewport extends Viewport {
    *   Per cartographic tradition, lat and lon are specified as degrees.
    */
   unprojectFlat(xy, scale = this.scale) {
-    return unprojectFlat(xy, scale);
+    return worldToLngLat(xy, scale);
   }
 
   /**
@@ -142,13 +142,13 @@ export default class WebMercatorViewport extends Viewport {
    * @return {Array} [lng,lat] new map center.
    */
   getMapCenterByLngLatPosition({lngLat, pos}) {
-    const fromLocation = pixelsToFlatCoordinates(pos, this.pixelUnprojectionMatrix);
-    const toLocation = projectFlat(lngLat, this.scale);
+    const fromLocation = pixelsToWorld(pos, this.pixelUnprojectionMatrix);
+    const toLocation = lngLatToWorld(lngLat, this.scale);
 
     const translate = vec2_add([], toLocation, vec2_negate([], fromLocation));
     const newCenter = vec2_add([], this.center, translate);
 
-    return unprojectFlat(newCenter, this.scale);
+    return worldToLngLat(newCenter, this.scale);
   }
 
   // Legacy method name

--- a/src/web-mercator-viewport.js
+++ b/src/web-mercator-viewport.js
@@ -4,13 +4,16 @@ import Viewport from './viewport';
 import {
   zoomToScale,
   getWorldPosition,
+  pixelsToFlatCoordinates,
   projectFlat,
   unprojectFlat,
   getProjectionMatrix,
-  getViewMatrix,
-  getMapCenterByLngLatPosition
+  getViewMatrix
 } from './web-mercator-utils';
 import fitBounds from './fit-bounds';
+
+import vec2_add from 'gl-vec2/add';
+import vec2_negate from 'gl-vec2/negate';
 
 export default class WebMercatorViewport extends Viewport {
   /**
@@ -139,13 +142,13 @@ export default class WebMercatorViewport extends Viewport {
    * @return {Array} [lng,lat] new map center.
    */
   getMapCenterByLngLatPosition({lngLat, pos}) {
-    return getMapCenterByLngLatPosition({
-      lngLat,
-      pos,
-      scale: this.scale,
-      center: this.center,
-      unprojectionMatrix: this.pixelUnprojectionMatrix
-    });
+    const fromLocation = pixelsToFlatCoordinates(pos, this.pixelUnprojectionMatrix);
+    const toLocation = projectFlat(lngLat, this.scale);
+
+    const translate = vec2_add([], toLocation, vec2_negate([], fromLocation));
+    const newCenter = vec2_add([], this.center, translate);
+
+    return unprojectFlat(newCenter, this.scale);
   }
 
   // Legacy method name

--- a/test/spec/web-mercator-utils.spec.js
+++ b/test/spec/web-mercator-utils.spec.js
@@ -11,7 +11,10 @@ import {
   getWorldPosition,
   getUncenteredViewMatrix,
   getViewMatrix,
-  getProjectionMatrix
+  getProjectionMatrix,
+  flatCoordinatesToPixels,
+  pixelsToFlatCoordinates,
+  getMapCenterByLngLatPosition
 } from 'viewport-mercator-project';
 
 import VIEWPORT_PROPS from '../utils/sample-viewports';
@@ -29,6 +32,9 @@ test('Viewport#imports', t => {
   t.ok(getUncenteredViewMatrix,
     'getUncenteredViewMatrix imports OK');
   t.ok(getProjectionMatrix, 'getProjectionMatrix imports OK');
+  t.ok(flatCoordinatesToPixels, 'flatCoordinatesToPixels imports OK');
+  t.ok(pixelsToFlatCoordinates, 'pixelsToFlatCoordinates imports OK');
+  t.ok(getMapCenterByLngLatPosition, 'getMapCenterByLngLatPosition imports OK');
   t.end();
 });
 

--- a/test/spec/web-mercator-utils.spec.js
+++ b/test/spec/web-mercator-utils.spec.js
@@ -4,16 +4,16 @@ import destination from '@turf/destination';
 import {toLowPrecision} from '../utils/test-utils';
 
 import {
-  projectFlat,
-  unprojectFlat,
+  lngLatToWorld,
+  worldToLngLat,
   getMeterZoom,
   getDistanceScales,
   getWorldPosition,
   getUncenteredViewMatrix,
   getViewMatrix,
   getProjectionMatrix,
-  flatCoordinatesToPixels,
-  pixelsToFlatCoordinates
+  worldToPixels,
+  pixelsToWorld
 } from 'viewport-mercator-project';
 
 import VIEWPORT_PROPS from '../utils/sample-viewports';
@@ -23,16 +23,16 @@ const DISTANCE_TOLERANCE_PIXELS = 2;
 const DISTANCE_SCALE_TEST_ZOOM = 12;
 
 test('Viewport#imports', t => {
-  t.ok(projectFlat, 'projectFlat imports OK');
-  t.ok(unprojectFlat, 'unprojectFlat imports OK');
+  t.ok(lngLatToWorld, 'lngLatToWorld imports OK');
+  t.ok(worldToLngLat, 'worldToLngLat imports OK');
   t.ok(getMeterZoom, 'getMeterZoom imports OK');
   t.ok(getWorldPosition, 'getWorldPosition imports OK');
   t.ok(getViewMatrix, 'getViewMatrix imports OK');
   t.ok(getUncenteredViewMatrix,
     'getUncenteredViewMatrix imports OK');
   t.ok(getProjectionMatrix, 'getProjectionMatrix imports OK');
-  t.ok(flatCoordinatesToPixels, 'flatCoordinatesToPixels imports OK');
-  t.ok(pixelsToFlatCoordinates, 'pixelsToFlatCoordinates imports OK');
+  t.ok(worldToPixels, 'worldToPixels imports OK');
+  t.ok(pixelsToWorld, 'pixelsToWorld imports OK');
   t.end();
 });
 
@@ -88,8 +88,8 @@ test('getDistanceScales#pixelsPerDegree', t => {
       const pt = [longitude + delta, latitude + delta];
 
       const realCoords = [
-        projectFlat(pt, scale)[0] - projectFlat([longitude, latitude], scale)[0],
-        -(projectFlat(pt, scale)[1] - projectFlat([longitude, latitude], scale)[1]),
+        lngLatToWorld(pt, scale)[0] - lngLatToWorld([longitude, latitude], scale)[0],
+        -(lngLatToWorld(pt, scale)[1] - lngLatToWorld([longitude, latitude], scale)[1]),
         z * getDistanceScales({longitude: pt[0], latitude: pt[1], scale}).pixelsPerMeter[2]
       ];
 
@@ -141,8 +141,8 @@ test('getDistanceScales#pixelsPerMeter', t => {
       pt = pt.geometry.coordinates;
 
       const realCoords = [
-        projectFlat(pt, scale)[0] - projectFlat([longitude, latitude], scale)[0],
-        -(projectFlat(pt, scale)[1] - projectFlat([longitude, latitude], scale)[1]),
+        lngLatToWorld(pt, scale)[0] - lngLatToWorld([longitude, latitude], scale)[0],
+        -(lngLatToWorld(pt, scale)[1] - lngLatToWorld([longitude, latitude], scale)[1]),
         z * getDistanceScales({longitude: pt[0], latitude: pt[1], scale}).pixelsPerMeter[2]
       ];
 

--- a/test/spec/web-mercator-utils.spec.js
+++ b/test/spec/web-mercator-utils.spec.js
@@ -13,8 +13,7 @@ import {
   getViewMatrix,
   getProjectionMatrix,
   flatCoordinatesToPixels,
-  pixelsToFlatCoordinates,
-  getMapCenterByLngLatPosition
+  pixelsToFlatCoordinates
 } from 'viewport-mercator-project';
 
 import VIEWPORT_PROPS from '../utils/sample-viewports';
@@ -34,7 +33,6 @@ test('Viewport#imports', t => {
   t.ok(getProjectionMatrix, 'getProjectionMatrix imports OK');
   t.ok(flatCoordinatesToPixels, 'flatCoordinatesToPixels imports OK');
   t.ok(pixelsToFlatCoordinates, 'pixelsToFlatCoordinates imports OK');
-  t.ok(getMapCenterByLngLatPosition, 'getMapCenterByLngLatPosition imports OK');
   t.end();
 });
 


### PR DESCRIPTION
Renames (legacy name is still supported):
- `projectFlat` util to `lngLatToWorld`
- `unprojectFlat` util to `worldToLngLat`
- `WebMercatorViewport.getLocationAtPoint` to `WebMercatorViewport.getMapCenterByLngLatPosition`

New exports:
- `worldToPixels`
- `pixelsToWorld`

  