### PR TITLE
assert isfinite for latitude in getMeterZoom

### DIFF
--- a/src/web-mercator-utils.js
+++ b/src/web-mercator-utils.js
@@ -67,7 +67,7 @@ export function worldToLngLat([x, y], scale) {
 // Returns the zoom level that gives a 1 meter pixel at a certain latitude
 // S=C*cos(y)/2^(z+8)
 export function getMeterZoom({latitude}) {
-  assert(latitude);
+  assert(isFinite(latitude));
   const latCosine = Math.cos(latitude * DEGREES_TO_RADIANS);
   return scaleToZoom(EARTH_CIRCUMFERENCE * latCosine) - 8;
 }

--- a/src/web-mercator-utils.js
+++ b/src/web-mercator-utils.js
@@ -67,7 +67,7 @@ export function worldToLngLat([x, y], scale) {
 // Returns the zoom level that gives a 1 meter pixel at a certain latitude
 // S=C*cos(y)/2^(z+8)
 export function getMeterZoom({latitude}) {
-  assert(isFinite(latitude));
+  assert(Number.isFinite(latitude));
   const latCosine = Math.cos(latitude * DEGREES_TO_RADIANS);
   return scaleToZoom(EARTH_CIRCUMFERENCE * latCosine) - 8;
 }
@@ -82,7 +82,7 @@ export function getDistanceScales({latitude, longitude, zoom, scale, highPrecisi
   // Calculate scale from zoom if not provided
   scale = scale !== undefined ? scale : zoomToScale(zoom);
 
-  assert(isFinite(latitude) && isFinite(longitude) && isFinite(scale));
+  assert(Number.isFinite(latitude) && Number.isFinite(longitude) && Number.isFinite(scale));
 
   const result = {};
   const worldSize = TILE_SIZE * scale;
@@ -261,7 +261,7 @@ export function getProjectionMatrix({
  */
 export function worldToPixels(xyz, pixelProjectionMatrix) {
   const [x, y, z = 0] = xyz;
-  assert(isFinite(x) && isFinite(y) && isFinite(z));
+  assert(Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z));
 
   return transformVector(pixelProjectionMatrix, [x, y, z, 1]);
 }
@@ -277,7 +277,7 @@ export function worldToPixels(xyz, pixelProjectionMatrix) {
  */
 export function pixelsToWorld(xyz, pixelUnprojectionMatrix, targetZ = 0) {
   const [x, y, z] = xyz;
-  assert(isFinite(x) && isFinite(y));
+  assert(Number.isFinite(x) && Number.isFinite(y));
 
   if (Number.isFinite(z)) {
     // Has depth component


### PR DESCRIPTION
make assert not fail when `latitude === 0`

```
"AssertionError: 0 == true
    at getMeterZoom (http://localhost:14919/javascripts/vendor.js:195018:24)
    at FirstPersonViewport.Viewport (http://localhost:14919/javascripts/vendor.js:81515:81)
    at new FirstPersonViewport (http://localhost:14919/javascripts/vendor.js:80881:123)
    at getViewportInstances (http://localhost:14919/javascripts/main.js:22979:28)
    at Core3DViewer.render (http://localhost:14919/javascripts/main.js:18217:59)
    at finishClassComponent (http://localhost:14919/javascripts/main.js:108142:31)
    at updateClassComponent (http://localhost:14919/javascripts/main.js:108119:12)
    at beginWork (http://localhost:14919/javascripts/main.js:108494:16)
    at performUnitOfWork (http://localhost:14919/javascripts/main.js:110493:16)
    at workLoop (http://localhost:14919/javascripts/main.js:110557:26)"
```