### PR TITLE
Add padding as object option to fitBounds

### DIFF
--- a/docs/api-reference/web-mercator-viewport.md
+++ b/docs/api-reference/web-mercator-viewport.md
@@ -101,7 +101,9 @@ Get a new flat viewport that fits around the given bounding box.
 * `bounds` ([[Number,Number],[Number,Number]]) - an array of two opposite corners of
 the bounding box. Each corner is specified in `[lon, lat]`.
 * `options` (Object)
-  + `options.padding` (Number, optional) - The amount of padding in pixels to add to the given bounds from the edge of the viewport.
+  + `options.padding` (Number|{top:Number, bottom: Number, left: Number, right: Number}, optional) - The amount of
+  padding in pixels to add to the given bounds from the edge of the viewport. If padding is set as object, all parameters are
+  required.
   + `options.offset` ([Number,Number], optional) - The center of the given bounds relative to the viewport's center, `[x, y]` measured in pixels.
 
 

--- a/src/fit-bounds.js
+++ b/src/fit-bounds.js
@@ -1,8 +1,6 @@
 import WebMercatorViewport from './web-mercator-viewport';
 import assert from 'assert';
 
-const ERR_PADDING = 'Padding object missing properties in fitBounds.';
-
 /**
  * * An object describing the padding to add to the bounds.
  * @typedef {Object} PaddingObject
@@ -36,7 +34,7 @@ export default function fitBounds({
 }) {
   const [[west, south], [east, north]] = bounds;
 
-  if (typeof padding === 'number') {
+  if (Number.isFinite(padding)) {
     const p = padding;
     padding = {
       top: p,
@@ -46,11 +44,10 @@ export default function fitBounds({
     };
   } else {
     // Make sure all the required properties are set
-    assert(typeof padding.top === 'number' &&
-      typeof padding.bottom === 'number' &&
-      typeof padding.left === 'number' &&
-      typeof padding.right === 'number',
-      ERR_PADDING
+    assert(Number.isFinite(padding.top) &&
+      Number.isFinite(padding.bottom) &&
+      Number.isFinite(padding.left) &&
+      Number.isFinite(padding.right)
     );
   }
   // Find how much we need to shift the center

--- a/src/fit-bounds.js
+++ b/src/fit-bounds.js
@@ -1,4 +1,16 @@
 import WebMercatorViewport from './web-mercator-viewport';
+import assert from 'assert';
+
+const ERR_PADDING = 'Padding object missing properties in fitBounds.';
+
+/**
+ * * An object describing the padding to add to the bounds.
+ * @typedef {Object} PaddingObject
+ * @property {Number} top - Padding from top in pixels to add to the given bounds
+ * @property {Number} bottom - Padding from bottom in pixels to add to the given bounds
+ * @property {Number} left - Padding from left in pixels to add to the given bounds
+ * @property {Number} right - Padding from right in pixels to add to the given bounds
+ */
 
 /**
  * Returns map settings {latitude, longitude, zoom}
@@ -7,7 +19,9 @@ import WebMercatorViewport from './web-mercator-viewport';
  * @param {Number} width - viewport width
  * @param {Number} height - viewport height
  * @param {Array} bounds - [[lon, lat], [lon, lat]]
- * @param {Number} [padding] - The amount of padding in pixels to add to the given bounds.
+ * @param {Number|PaddingObject} [padding] - The amount of padding in pixels
+ *  to add to the given bounds. Can also be an object with top, bottom, left and right
+ *  properties defining the padding.
  * @param {Array} [offset] - The center of the given bounds relative to the map's center,
  *    [x, y] measured in pixels.
  * @returns {Object} - latitude, longitude and zoom
@@ -21,6 +35,27 @@ export default function fitBounds({
   offset = [0, 0]
 }) {
   const [[west, south], [east, north]] = bounds;
+
+  if (typeof padding === 'number') {
+    const p = padding;
+    padding = {
+      top: p,
+      bottom: p,
+      left: p,
+      right: p
+    };
+  } else {
+    // Make sure all the required properties are set
+    assert(typeof padding.top === 'number' &&
+      typeof padding.bottom === 'number' &&
+      typeof padding.left === 'number' &&
+      typeof padding.right === 'number',
+      ERR_PADDING
+    );
+  }
+  // Find how much we need to shift the center
+  const verticalOffset = (padding.top - padding.bottom) / 2;
+  const lateralOffset = (padding.left - padding.right) / 2;
 
   const viewport = new WebMercatorViewport({
     width,
@@ -37,12 +72,12 @@ export default function fitBounds({
     Math.abs(se[1] - nw[1])
   ];
   const center = [
-    (se[0] + nw[0]) / 2,
-    (se[1] + nw[1]) / 2
+    (se[0] + nw[0]) / 2 + lateralOffset,
+    (se[1] + nw[1]) / 2 + verticalOffset
   ];
 
-  const scaleX = (width - padding * 2 - Math.abs(offset[0]) * 2) / size[0];
-  const scaleY = (height - padding * 2 - Math.abs(offset[1]) * 2) / size[1];
+  const scaleX = (width - padding.left - padding.right - Math.abs(offset[0]) * 2) / size[0];
+  const scaleY = (height - padding.top - padding.bottom - Math.abs(offset[1]) * 2) / size[1];
 
   const centerLngLat = viewport.unproject(center);
   const zoom = viewport.zoom + Math.log2(Math.abs(Math.min(scaleX, scaleY)));

--- a/src/fit-bounds.js
+++ b/src/fit-bounds.js
@@ -50,9 +50,6 @@ export default function fitBounds({
       Number.isFinite(padding.right)
     );
   }
-  // Find how much we need to shift the center
-  const verticalOffset = (padding.top - padding.bottom) / 2;
-  const lateralOffset = (padding.left - padding.right) / 2;
 
   const viewport = new WebMercatorViewport({
     width,
@@ -64,17 +61,25 @@ export default function fitBounds({
 
   const nw = viewport.project([west, north]);
   const se = viewport.project([east, south]);
+
+  // width/height on the Web Mercator plane
   const size = [
     Math.abs(se[0] - nw[0]),
     Math.abs(se[1] - nw[1])
   ];
-  const center = [
-    (se[0] + nw[0]) / 2 + lateralOffset,
-    (se[1] + nw[1]) / 2 + verticalOffset
-  ];
 
+  // scale = screen pixels per unit on the Web Mercator plane
   const scaleX = (width - padding.left - padding.right - Math.abs(offset[0]) * 2) / size[0];
   const scaleY = (height - padding.top - padding.bottom - Math.abs(offset[1]) * 2) / size[1];
+
+  // Find how much we need to shift the center
+  const offsetX = (padding.right - padding.left) / 2 / scaleX;
+  const offsetY = (padding.bottom - padding.top) / 2 / scaleY;
+
+  const center = [
+    (se[0] + nw[0]) / 2 + offsetX,
+    (se[1] + nw[1]) / 2 + offsetY
+  ];
 
   const centerLngLat = viewport.unproject(center);
   const zoom = viewport.zoom + Math.log2(Math.abs(Math.min(scaleX, scaleY)));

--- a/test/spec/fit-bounds.spec.js
+++ b/test/spec/fit-bounds.spec.js
@@ -29,6 +29,20 @@ const FITBOUNDS_TEST_CASES = [
       latitude: 64.86850056273362,
       zoom: 12.89199533073045
     }
+  ],
+  [
+    {
+      width: 600,
+      height: 400,
+      bounds: [[-23.407, 64.863], [-23.406, 64.874]],
+      padding: {top: 100, bottom: 10, left: 30, right: 30},
+      offset: [0, -40]
+    },
+    {
+      longitude: -23.406499999999973,
+      latitude: 47.666802977,
+      zoom: 12.476957831
+    }
   ]
 ];
 

--- a/test/spec/fit-bounds.spec.js
+++ b/test/spec/fit-bounds.spec.js
@@ -40,7 +40,7 @@ const FITBOUNDS_TEST_CASES = [
     },
     {
       longitude: -23.406499999999973,
-      latitude: 47.666802977,
+      latitude: 64.870857602,
       zoom: 12.476957831
     }
   ]


### PR DESCRIPTION
This adds an option to set the padding as an object with `top`, `bottom`, `right`, and `left` properties to set different padding for each side when calling the `fitBounds` method. This is useful if you have UI overlaying on one side of the map and you want to have the bounds fill up the rest of the available area.

The api is similar to the way [Mapbox-gl-js's fitBounds](https://www.mapbox.com/mapbox-gl-js/api/#map#fitbounds) method works.

I couldn't find a good example of how this kind of object would be documented, so I ended up describing it inline. I hope that's clear enough, but if there's another way you'd prefer, I'll update accordingly.

Thanks for a great set of tools around mapping and let me know if there's anything I can improve!