### PR TITLE
Flip y in distance scales

### DIFF
--- a/src/web-mercator-utils.js
+++ b/src/web-mercator-utils.js
@@ -106,11 +106,18 @@ export function getDistanceScales({latitude, longitude, zoom, scale, highPrecisi
    */
   const altPixelsPerMeter = worldSize / EARTH_CIRCUMFERENCE / latCosine;
 
-  result.pixelsPerMeter = [altPixelsPerMeter, altPixelsPerMeter, altPixelsPerMeter];
-  result.metersPerPixel = [1 / altPixelsPerMeter, 1 / altPixelsPerMeter, 1 / altPixelsPerMeter];
+  /**
+   * LngLat: longitude -> east and latitude -> north (bottom left)
+   * UTM meter offset: x -> east and y -> north (bottom left)
+   * World space: x -> east and y -> south (top left)
+   *
+   * Y needs to be flipped when converting delta degree/meter to delta pixels
+   */
+  result.pixelsPerMeter = [altPixelsPerMeter, -altPixelsPerMeter, altPixelsPerMeter];
+  result.metersPerPixel = [1 / altPixelsPerMeter, -1 / altPixelsPerMeter, 1 / altPixelsPerMeter];
 
-  result.pixelsPerDegree = [pixelsPerDegreeX, pixelsPerDegreeY, altPixelsPerMeter];
-  result.degreesPerPixel = [1 / pixelsPerDegreeX, 1 / pixelsPerDegreeY, 1 / altPixelsPerMeter];
+  result.pixelsPerDegree = [pixelsPerDegreeX, -pixelsPerDegreeY, altPixelsPerMeter];
+  result.degreesPerPixel = [1 / pixelsPerDegreeX, -1 / pixelsPerDegreeY, 1 / altPixelsPerMeter];
 
   /**
    * Taylor series 2nd order for 1/latCosine
@@ -124,7 +131,7 @@ export function getDistanceScales({latitude, longitude, zoom, scale, highPrecisi
     const altPixelsPerDegree2 = worldSize / EARTH_CIRCUMFERENCE * latCosine2;
     const altPixelsPerMeter2 = altPixelsPerDegree2 / pixelsPerDegreeY * altPixelsPerMeter;
 
-    result.pixelsPerDegree2 = [0, pixelsPerDegreeY2, altPixelsPerDegree2];
+    result.pixelsPerDegree2 = [0, -pixelsPerDegreeY2, altPixelsPerDegree2];
     result.pixelsPerMeter2 = [altPixelsPerMeter2, 0, altPixelsPerMeter2];
   }
 

--- a/test/spec/web-mercator-utils.spec.js
+++ b/test/spec/web-mercator-utils.spec.js
@@ -91,7 +91,7 @@ test('getDistanceScales#pixelsPerDegree', t => {
 
       const realCoords = [
         lngLatToWorld(pt, scale)[0] - lngLatToWorld([longitude, latitude], scale)[0],
-        -(lngLatToWorld(pt, scale)[1] - lngLatToWorld([longitude, latitude], scale)[1]),
+        lngLatToWorld(pt, scale)[1] - lngLatToWorld([longitude, latitude], scale)[1],
         z * getDistanceScales({longitude: pt[0], latitude: pt[1], scale}).pixelsPerMeter[2]
       ];
 
@@ -144,7 +144,7 @@ test('getDistanceScales#pixelsPerMeter', t => {
 
       const realCoords = [
         lngLatToWorld(pt, scale)[0] - lngLatToWorld([longitude, latitude], scale)[0],
-        -(lngLatToWorld(pt, scale)[1] - lngLatToWorld([longitude, latitude], scale)[1]),
+        lngLatToWorld(pt, scale)[1] - lngLatToWorld([longitude, latitude], scale)[1],
         z * getDistanceScales({longitude: pt[0], latitude: pt[1], scale}).pixelsPerMeter[2]
       ];
 
@@ -170,7 +170,7 @@ test('getMeterZoom', t => {
     const zoom = getMeterZoom({latitude});
 
     const {pixelsPerMeter} = getDistanceScales({latitude, longitude: 0, zoom});
-    t.deepEqual(toLowPrecision(pixelsPerMeter), [1, 1, 1], 'zoom yields 1 pixel per meter');
+    t.deepEqual(toLowPrecision(pixelsPerMeter), [1, -1, 1], 'zoom yields 1 pixel per meter');
   }
 
   t.end();


### PR DESCRIPTION
For https://github.com/uber-common/viewport-mercator-project/issues/73

You can see in the test case that the user of distance scales should no longer have to manually flip Y to match the world space orientation.

This new behavior also matches what is described in the documentation: https://github.com/uber-common/viewport-mercator-project/blob/master/docs/api-reference/web-mercator-utils.md#getdistancescalesviewport

### Change list

- Flip y in distance scales
- Fix test-browser