### PR TITLE
Add babel runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,22 +3,19 @@
   "env": {
     "es5": {
       "presets": [
-        [ "@babel/env", {
-          forceAllTransforms: true,
-          "modules": "commonjs"
-        }]
+        "@babel/env"
       ],
       "plugins": [
+        "@babel/transform-runtime",
         "version-inline"
       ]
     },
     "esm": {
       "presets": [
-        [ "@babel/env", {
-          "modules": false
-        }]
+        ["@babel/env", { "modules": false }],
       ],
       "plugins": [
+        ["@babel/transform-runtime", { useESModules: true }],
         "version-inline"
       ]
     },
@@ -34,9 +31,10 @@
             "node": "8"
           },
           "modules": false
-        }]
+        } ],
       ],
       "plugins": [
+        ["@babel/transform-runtime", { useESModules: true }],
         "version-inline"
       ]
     },

--- a/package.json
+++ b/package.json
@@ -33,11 +33,13 @@
     "test-bundle-size": "./scripts/build.sh  && webpack --config test/webpack.config.js --env.analyze --env.es6"
   },
   "dependencies": {
+    "@babel/runtime": "^7.0.0",
     "math.gl": "^2.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
+    "@babel/plugin-transform-runtime": "^7.0.0",
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@turf/destination": "^5.0.4",


### PR DESCRIPTION
- replaced removed es2015 with env preset
- added babel runtime to share babel helpers with all modules in this
package and all others

Ref https://github.com/uber-common/viewport-mercator-project/pull/75#issuecomment-421507675