### PR TITLE
Remove math.gl dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "gl-matrix": "^3.0.0-0",
-    "math.gl": "^2.1.0"
+    "gl-matrix": "^3.0.0-0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
@@ -53,6 +52,7 @@
     "html-webpack-plugin": "^3.0.7",
     "jsdom": "~9.9.1",
     "mapbox-gl": "~0.49.0",
+    "math.gl": "^2.1.0",
     "mock-browser": "^0.92.14",
     "module-alias": "^2.0.0",
     "pre-commit": "^1.2.2",

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -1,6 +1,5 @@
 // View and Projection Matrix management
 
-import {equals} from 'math.gl';
 import {createMat4} from './math-utils';
 import {worldToPixels, pixelsToWorld} from './web-mercator-utils';
 
@@ -105,8 +104,8 @@ export default class Viewport {
 
     return viewport.width === this.width &&
       viewport.height === this.height &&
-      equals(viewport.projectionMatrix, this.projectionMatrix) &&
-      equals(viewport.viewMatrix, this.viewMatrix);
+      mat4.equals(viewport.projectionMatrix, this.projectionMatrix) &&
+      mat4.equals(viewport.viewMatrix, this.viewMatrix);
   }
 
   /**

--- a/src/web-mercator-utils.js
+++ b/src/web-mercator-utils.js
@@ -1,10 +1,10 @@
 // TODO - THE UTILITIES IN THIS FILE SHOULD BE IMPORTED FROM WEB-MERCATOR-VIEWPORT MODULE
 
-import {Vector3} from 'math.gl';
 import {createMat4, transformVector} from './math-utils';
 
 import * as mat4 from 'gl-matrix/mat4';
 import * as vec2 from 'gl-matrix/vec2';
+import * as vec3 from 'gl-matrix/vec3';
 import assert from './assert';
 
 // CONSTANTS
@@ -200,7 +200,7 @@ export function getViewMatrix({
   }
 
   if (center) {
-    mat4.translate(vm, vm, new Vector3(center).negate());
+    mat4.translate(vm, vm, vec3.negate([], center));
   }
 
   return vm;


### PR DESCRIPTION
For https://github.com/uber/react-map-gl/issues/640

The goal is to remove math.gl from react-map-gl's dependencies. We can continue to investigate the build issue under IE11 as it remains an issue for deck.gl.

@TrySound