### PR TITLE
Provide bundles as entry points

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,43 +1,6 @@
 {
   "comments": false,
   "env": {
-    "es5": {
-      "presets": [
-        "@babel/env"
-      ],
-      "plugins": [
-        "@babel/transform-runtime",
-        "version-inline"
-      ]
-    },
-    "esm": {
-      "presets": [
-        ["@babel/env", { "modules": false }],
-      ],
-      "plugins": [
-        ["@babel/transform-runtime", { useESModules: true }],
-        "version-inline"
-      ]
-    },
-    "es6": {
-      "presets": [
-        [ "@babel/env", {
-          "targets": {
-            "chrome": "60",
-            "edge": "15",
-            "firefox": "53",
-            "ios": "10.3",
-            "safari": "10.1",
-            "node": "8"
-          },
-          "modules": false
-        } ],
-      ],
-      "plugins": [
-        ["@babel/transform-runtime", { useESModules: true }],
-        "version-inline"
-      ]
-    },
     "test": {
       "plugins": [
         "istanbul"

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "url": "git+https://github.com/uber-common/viewport-mercator-project.git"
   },
   "homepage": "https://github.com/uber-common/viewport-mercator-project#readme",
-  "main": "dist/es5/index.js",
-  "module": "dist/esm/index.js",
-  "esnext": "dist/es6/index.js",
+  "main": "dist/viewport-mercator-project.es5.js",
+  "module": "dist/viewport-mercator-project.esm.js",
+  "esnext": "dist/viewport-mercator-project.es6.js",
   "files": [
     "src",
     "dist"
@@ -19,18 +19,17 @@
   "sideEffects": false,
   "scripts": {
     "start": "npm run test",
-    "clean": "rm -fr dist && mkdir -p dist/es5 dist/esm dist/es6",
-    "build": "npm run clean && ./scripts/build.sh && ./scripts/collect-metrics.sh",
+    "build": "rm -rf dist && rollup -c && ./scripts/collect-metrics.sh",
     "lint": "eslint src test examples && npm run lint-yarn",
     "lint-yarn": "!(grep -q unpm.u yarn.lock) || (echo 'Please rebuild yarn file using public npmrc' && false)",
     "precommit": "npm test",
     "publish-prod": "npm run build && npm run test && npm publish",
     "publish-beta": "npm run build && npm run test && npm publish --tag beta",
-    "test": "npm run lint && npm run test-node && ./scripts/build.sh",
+    "test": "npm run lint && npm run test-node && npm run build",
     "test-fast": "npm run test-node",
     "test-node": "node test/node.js",
     "test-browser": "webpack-dev-server --config test/webpack.config.js --env.testBrowser --progress --hot --open",
-    "test-bundle-size": "./scripts/build.sh && webpack --config test/webpack.config.js --env.analyze --env.es6"
+    "test-bundle-size": "npm run build && webpack --config test/webpack.config.js --env.analyze --env.es6"
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
@@ -57,6 +56,8 @@
     "module-alias": "^2.0.0",
     "pre-commit": "^1.2.2",
     "reify": "^0.5.4",
+    "rollup": "^1.15.6",
+    "rollup-plugin-babel": "^4.3.2",
     "round-precision": "^1.0.0",
     "sinon": "^1.17.7",
     "source-map-loader": "^0.2.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,70 @@
+import path from "path";
+import babel from "rollup-plugin-babel";
+import pkg from "./package.json";
+
+const input = "./src/index.js";
+const external = id => !id.startsWith(".") && !path.isAbsolute(id);
+
+export default [
+  {
+    input,
+    output: {
+      file: pkg.main,
+      format: "cjs",
+      exports: "named",
+      sourcemap: true
+    },
+    external,
+    plugins: [
+      babel({
+        runtimeHelpers: true,
+        presets: ["@babel/env"],
+        plugins: ["@babel/transform-runtime", "version-inline"]
+      })
+    ]
+  },
+  {
+    input,
+    output: { file: pkg.module, format: "esm", sourcemap: true },
+    external,
+    plugins: [
+      babel({
+        runtimeHelpers: true,
+        presets: ["@babel/env"],
+        plugins: [
+          ["@babel/transform-runtime", { useESModules: true }],
+          "version-inline"
+        ]
+      })
+    ]
+  },
+  {
+    input,
+    output: { file: pkg.esnext, format: "esm", sourcemap: true },
+    external,
+    plugins: [
+      babel({
+        runtimeHelpers: true,
+        presets: [
+          [
+            "@babel/env",
+            {
+              targets: {
+                chrome: "60",
+                edge: "15",
+                firefox: "53",
+                ios: "10.3",
+                safari: "10.1",
+                node: "8"
+              }
+            }
+          ]
+        ],
+        plugins: [
+          ["@babel/transform-runtime", { useESModules: true }],
+          "version-inline"
+        ]
+      })
+    ]
+  }
+];

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-export PATH=$PATH:node_modules/.bin
-
-BABEL_ENV=es6 babel src --out-dir dist/es6 --source-maps --ignore 'node_modules/' &&
-BABEL_ENV=esm babel src --out-dir dist/esm --source-maps --ignore 'node_modules/' &&
-BABEL_ENV=es5 babel src --out-dir dist/es5 --source-maps --ignore 'node_modules/'


### PR DESCRIPTION
With current setup I get this warning

```
Circular dependency: ../node_modules/viewport-mercator-project/dist/esm/web-mercator-viewport.js -> ../node_modules/viewport-mercator-project/dist/esm/fit-bounds.js -> ../node_modules/viewport-mercator-project/dist/esm/web-mercator-viewport.js
```

Bundling all modules will eliminate this warning for users and make it
visible only for you.

As another benefit user bundler will need to resolve only one module in
this package which may slightly speed up bundling.