### PR TITLE
Fix for Infinity zoom when bounds are the same point

### DIFF
--- a/src/fit-bounds.js
+++ b/src/fit-bounds.js
@@ -89,7 +89,7 @@ export default function fitBounds({
   ];
 
   const centerLngLat = viewport.unproject(center);
-  const zoom = Math.min(16, viewport.zoom + Math.log2(Math.abs(Math.min(scaleX, scaleY))));
+  const zoom = Math.min(22, viewport.zoom + Math.log2(Math.abs(Math.min(scaleX, scaleY))));
 
   return {
     longitude: centerLngLat[0],

--- a/src/fit-bounds.js
+++ b/src/fit-bounds.js
@@ -89,7 +89,7 @@ export default function fitBounds({
   ];
 
   const centerLngLat = viewport.unproject(center);
-  const zoom = viewport.zoom + Math.log2(Math.abs(Math.min(scaleX, scaleY)));
+  const zoom = Math.min(16, viewport.zoom + Math.log2(Math.abs(Math.min(scaleX, scaleY))));
 
   return {
     longitude: centerLngLat[0],

--- a/test/spec/fit-bounds.spec.js
+++ b/test/spec/fit-bounds.spec.js
@@ -18,6 +18,18 @@ const FITBOUNDS_TEST_CASES = [
   ],
   [
     {
+      width: 100,
+      height: 100,
+      bounds: [[-73.9876, 40.7661], [-73.9876, 40.7661]]
+    },
+    {
+      longitude: -73.9876,
+      latitude: 40.7661,
+      zoom: 16
+    }
+  ],
+  [
+    {
       width: 600,
       height: 400,
       bounds: [[-23.407, 64.863], [-23.406, 64.874]],

--- a/test/spec/fit-bounds.spec.js
+++ b/test/spec/fit-bounds.spec.js
@@ -25,7 +25,7 @@ const FITBOUNDS_TEST_CASES = [
     {
       longitude: -73.9876,
       latitude: 40.7661,
-      zoom: 16
+      zoom: 22
     }
   ],
   [


### PR DESCRIPTION
When viewport bounds are the same point (i.e. the extent of a list of 1 point), the returned zoom is `Infinity`. This causes an assertion error crash in `lngLatToWorld` because `scale` is Infinite.

I chose 22 because https://en.wikipedia.org/wiki/Tiled_web_map says that `about 22 zoom levels are sufficient for most practical purposes`. Alternatively we could set the zoom level to 1.

I would say this should be pushed to userland code, but the internal crash and the unwieldiness of checking for Infinity seems like it should be handled in the lib.