### PR TITLE
fitBounds(): accept bounds coordinates in either order

### DIFF
--- a/src/fit-bounds.js
+++ b/src/fit-bounds.js
@@ -67,8 +67,8 @@ export default function fitBounds({
 
   // width/height on the Web Mercator plane
   const size = [
-    Math.abs(Math.max(se[0] - nw[0], minExtent)),
-    Math.abs(Math.max(se[1] - nw[1], minExtent))
+    Math.max(Math.abs(se[0] - nw[0]), minExtent),
+    Math.max(Math.abs(se[1] - nw[1]), minExtent)
   ];
 
   const targetSize = [

--- a/test/spec/fit-bounds.spec.js
+++ b/test/spec/fit-bounds.spec.js
@@ -8,7 +8,21 @@ const FITBOUNDS_TEST_CASES = [
     {
       width: 100,
       height: 100,
+      // southwest bound first
       bounds: [[-73.9876, 40.7661], [-72.9876, 41.7661]]
+    },
+    {
+      longitude: -73.48759999999997,
+      latitude: 41.26801443944763,
+      zoom: 5.723804361273887
+    }
+  ],
+  [
+    {
+      width: 100,
+      height: 100,
+      // northeast bound first
+      bounds: [[-72.9876, 41.7661], [-73.9876, 40.7661]]
     },
     {
       longitude: -73.48759999999997,


### PR DESCRIPTION
This is meant to fix: https://github.com/uber-common/viewport-mercator-project/issues/101